### PR TITLE
Improved handling of focus drift during scanning, and focusing narrowed to middle of each image

### DIFF
--- a/wsexperiment.py
+++ b/wsexperiment.py
@@ -52,19 +52,21 @@ class WSExperiment(Experiment):
         # And finally move the stage to the best focus position.
         self.scope.stage.move_to_pos(best_position)
 
-    def raster_scan(self, dx=[0], dy=[0], dz=[0]):
+    def raster_scan(self, dx=[None], dy=[None], dz=[None]):
         """Iterate over positions - returns a tuple of (index, pos) each time"""
         stage = self.scope.stage
-        initial_pos = stage.position
-        xs = np.array(dx) + initial_pos[0]
-        ys = np.array(dy) + initial_pos[1]
-        zs = np.array(dz) + initial_pos[2]
+        origin = stage.position
+
         try:
-            for k, z in enumerate(zs):
-                for j, y in enumerate(ys):
-                    for i, x in enumerate(xs):
-                        stage.move_to_pos([x, y, z])
-                        yield np.array([i, j, k]), np.array([x, y, z])
+            for k, z in enumerate(dz):
+                for j, y in enumerate(dy):
+                    for i, x in enumerate(dx):
+                        new_x = stage.position[0] if x is None else (origin[0] + x)
+                        new_y = stage.position[1] if y is None else (origin[1] + y)
+                        new_z = stage.position[2] if z is None else (origin[2] + z)
+                        new_pos = [new_x, new_y, new_z]
+                        stage.move_to_pos(new_pos)
+                        yield np.array([i, j, k]), np.array(new_pos)
         except KeyboardInterrupt:
             print "Keyboard Interrupt: aborting scan."
             raise KeyboardInterrupt
@@ -72,7 +74,7 @@ class WSExperiment(Experiment):
             print "An error occurred.  Moving back to initial position."
             raise e
         finally:
-            stage.move_to_pos(initial_pos)
+            stage.move_to_pos(origin)
 
     def _compensate_image(self, image, mode):
         # Lazy-load the compensation factor image.


### PR DESCRIPTION
The raster_scan function has been improved so that the z-axis isn't always returned to the origin's z-axis value when moving to each new tile. Instead, `None` is used inplace of a numeric value to indicate that any axis, x, y or z, should not be moved during the raster scan. The upshot is that when moving to a new tile position, the current auto-focus z-position is retained from tile to tile.

Additionally, we remember the z-axis position of the focus point for the first tile in each row, so that when the first tile in the next row is being scanned, we can use the focus point from the previous row as a good first estimate.

Finally, focusing is now limited to the middle 1/3 of the image in both the x and y axes. This should slightly speed up the sharpness measure calculation. More importantly, it will exclude regions of the image where spherical aberations cause the image content to be out of focus anyway.
